### PR TITLE
za concordances, placetype local, and more

### DIFF
--- a/data/110/873/050/7/1108730507.geojson
+++ b/data/110/873/050/7/1108730507.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.178388,
-    "geom:area_square_m":1979190030.130318,
+    "geom:area_square_m":1979190030.130133,
     "geom:bbox":"28.06561,-26.46558,28.52715,-25.903407",
     "geom:latitude":-26.198902,
     "geom:longitude":28.312611,
@@ -137,9 +137,10 @@
         "hasc:id":"ZA.GT.EK",
         "wd:id":"Q326891"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZA",
     "wof:created":1478731947,
-    "wof:geomhash":"5c4e21015f68ccbec2374fb9e3784a42",
+    "wof:geomhash":"7135eadc7186f9d7b55474c4cd64bd3d",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -165,7 +166,7 @@
         "ven",
         "nbl"
     ],
-    "wof:lastmodified":1690927946,
+    "wof:lastmodified":1695886611,
     "wof:name":"Ekurhuleni",
     "wof:parent_id":85688923,
     "wof:placetype":"county",

--- a/data/110/873/050/9/1108730509.geojson
+++ b/data/110/873/050/9/1108730509.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.148521,
-    "geom:area_square_m":1648128685.921426,
+    "geom:area_square_m":1648128685.921526,
     "geom:bbox":"27.71427,-26.52629,28.21446,-25.90283",
     "geom:latitude":-26.176733,
     "geom:longitude":27.96352,
@@ -120,9 +120,10 @@
         "hasc:id":"ZA.GT.JO",
         "wd:id":"Q2346838"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZA",
     "wof:created":1478731948,
-    "wof:geomhash":"ec6a722fedf0b2ff9ad58d9069c51b38",
+    "wof:geomhash":"44c0a66d32ade12247b16d4e09b83ff8",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -148,7 +149,7 @@
         "ven",
         "nbl"
     ],
-    "wof:lastmodified":1690927946,
+    "wof:lastmodified":1695886553,
     "wof:name":"Johannesburg",
     "wof:parent_id":85688923,
     "wof:placetype":"county",

--- a/data/110/873/051/3/1108730513.geojson
+++ b/data/110/873/051/3/1108730513.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.265207,
-    "geom:area_square_m":2751890968.472474,
+    "geom:area_square_m":2751890968.472825,
     "geom:bbox":"27.15761,-33.28507,28.0811,-32.674",
     "geom:latitude":-32.948006,
     "geom:longitude":27.598864,
@@ -109,11 +109,13 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "meso:local_id":"BUF",
         "wd:id":"Q1002006"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"ZA",
     "wof:created":1478731950,
-    "wof:geomhash":"8af9ab79ef88a7b1e77450c0d0075d6c",
+    "wof:geomhash":"ec922d9ffbd295fec862dd98af66978f",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -139,7 +141,7 @@
         "ven",
         "nbl"
     ],
-    "wof:lastmodified":1690927955,
+    "wof:lastmodified":1695886601,
     "wof:name":"Buffalo City",
     "wof:parent_id":85688927,
     "wof:placetype":"county",

--- a/data/110/873/051/7/1108730517.geojson
+++ b/data/110/873/051/7/1108730517.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.027643,
-    "geom:area_square_m":21131270158.196766,
+    "geom:area_square_m":21131270158.19989,
     "geom:bbox":"25.88731,-33.49633,29.09485,-31.78706",
     "geom:latitude":-32.559788,
     "geom:longitude":27.456874,
@@ -116,9 +116,10 @@
         "hasc:id":"ZA.EC.AT",
         "wd:id":"Q455705"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZA",
     "wof:created":1478731955,
-    "wof:geomhash":"9931df4d1fbcf8e2d30b692408b65eb5",
+    "wof:geomhash":"04981bc0ca977fc904ab8c377b5a1ffc",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -144,7 +145,7 @@
         "ven",
         "nbl"
     ],
-    "wof:lastmodified":1690927954,
+    "wof:lastmodified":1695886603,
     "wof:name":"Amathole",
     "wof:parent_id":85688927,
     "wof:placetype":"county",

--- a/data/110/873/051/9/1108730519.geojson
+++ b/data/110/873/051/9/1108730519.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":3.467002,
-    "geom:area_square_m":36437151960.216713,
+    "geom:area_square_m":36437151960.217056,
     "geom:bbox":"24.50391,-32.53792,28.38245,-31.18367",
     "geom:latitude":-31.793348,
     "geom:longitude":26.448484,
@@ -118,9 +118,10 @@
         "hasc:id":"ZA.EC.CH",
         "wd:id":"Q1077283"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZA",
     "wof:created":1478731958,
-    "wof:geomhash":"9716678bed2e415ae8bd99b11bbefc8e",
+    "wof:geomhash":"f820b1c1988dd1876953ff0ce7dae582",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -146,7 +147,7 @@
         "ven",
         "nbl"
     ],
-    "wof:lastmodified":1690927952,
+    "wof:lastmodified":1695886583,
     "wof:name":"Chris Hani",
     "wof:parent_id":85688927,
     "wof:placetype":"county",

--- a/data/110/873/052/1/1108730521.geojson
+++ b/data/110/873/052/1/1108730521.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.417897,
-    "geom:area_square_m":25642735419.141636,
+    "geom:area_square_m":25642735419.141613,
     "geom:bbox":"25.37782,-31.48531,28.69813,-30.31323",
     "geom:latitude":-30.941976,
     "geom:longitude":27.057694,
@@ -119,9 +119,10 @@
         "hasc:id":"ZA.EC.UH",
         "wd:id":"Q654849"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZA",
     "wof:created":1478731960,
-    "wof:geomhash":"96ac025c61bbe65673941f52c124b77d",
+    "wof:geomhash":"005e92f93340b3c6de999b327cecbdf3",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -147,7 +148,7 @@
         "ven",
         "nbl"
     ],
-    "wof:lastmodified":1690927930,
+    "wof:lastmodified":1695886595,
     "wof:name":"Joe Gqabi",
     "wof:parent_id":85688927,
     "wof:placetype":"county",

--- a/data/110/873/052/3/1108730523.geojson
+++ b/data/110/873/052/3/1108730523.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.152202,
-    "geom:area_square_m":12152142994.009302,
+    "geom:area_square_m":12152142994.010977,
     "geom:bbox":"28.30203,-32.05935,30.04764,-30.77167",
     "geom:latitude":-31.465015,
     "geom:longitude":29.050969,
@@ -67,9 +67,10 @@
     "wof:concordances":{
         "hasc:id":"ZA.EC.TA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZA",
     "wof:created":1478731963,
-    "wof:geomhash":"3680c0107967d6bd379b19b0d64cb637",
+    "wof:geomhash":"8d4e657c4fd65a0e63f322bcf5d2120e",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -95,7 +96,7 @@
         "ven",
         "nbl"
     ],
-    "wof:lastmodified":1627523015,
+    "wof:lastmodified":1695886236,
     "wof:name":"O.R.Tambo",
     "wof:parent_id":85688927,
     "wof:placetype":"county",

--- a/data/110/873/052/5/1108730525.geojson
+++ b/data/110/873/052/5/1108730525.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.010062,
-    "geom:area_square_m":10742631879.565639,
+    "geom:area_square_m":10742631879.56531,
     "geom:bbox":"28.20686,-31.29833,30.19472,-30.0018",
     "geom:latitude":-30.668034,
     "geom:longitude":29.154902,
@@ -130,9 +130,10 @@
         "hasc:id":"ZA.EC.AN",
         "wd:id":"Q1664120"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZA",
     "wof:created":1478731966,
-    "wof:geomhash":"ef2b37bb5482821dab5944e3e8c2951f",
+    "wof:geomhash":"d398ac51388d6edda6966a40e5e62b06",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -158,7 +159,7 @@
         "ven",
         "nbl"
     ],
-    "wof:lastmodified":1690927931,
+    "wof:lastmodified":1695886573,
     "wof:name":"Alfred Nzo",
     "wof:parent_id":85688927,
     "wof:placetype":"county",

--- a/data/110/873/052/7/1108730527.geojson
+++ b/data/110/873/052/7/1108730527.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.190539,
-    "geom:area_square_m":1957742665.435821,
+    "geom:area_square_m":1957742695.998837,
     "geom:bbox":"25.19221,-34.05076,25.868165,-33.55308",
     "geom:latitude":-33.804029,
     "geom:longitude":25.492346,
@@ -136,9 +136,10 @@
         "hasc:id":"ZA.EC.NM",
         "wd:id":"Q1856565"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZA",
     "wof:created":1478731969,
-    "wof:geomhash":"e3678538b87c0457495ed79d0283ea2b",
+    "wof:geomhash":"b4ae80628f50570e5ce0307c57d11cc5",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -164,7 +165,7 @@
         "ven",
         "nbl"
     ],
-    "wof:lastmodified":1690927929,
+    "wof:lastmodified":1695886596,
     "wof:name":"Nelson Mandela Bay",
     "wof:parent_id":85688927,
     "wof:placetype":"county",

--- a/data/110/873/053/1/1108730531.geojson
+++ b/data/110/873/053/1/1108730531.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":3.197844,
-    "geom:area_square_m":34291753677.476845,
+    "geom:area_square_m":34291753677.476974,
     "geom:bbox":"24.34662,-30.69408,27.41033,-28.828258",
     "geom:latitude":-29.859277,
     "geom:longitude":25.736725,
@@ -104,9 +104,10 @@
         "hasc:id":"ZA.FS.XH",
         "wd:id":"Q2006764"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZA",
     "wof:created":1478731971,
-    "wof:geomhash":"da38e3cebbce60038646a12f520c3cc1",
+    "wof:geomhash":"ef2881055976433a8310ee3cea57a476",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -132,7 +133,7 @@
         "ven",
         "nbl"
     ],
-    "wof:lastmodified":1690927927,
+    "wof:lastmodified":1695886459,
     "wof:name":"Xhariep",
     "wof:parent_id":85688915,
     "wof:placetype":"county",

--- a/data/110/873/053/3/1108730533.geojson
+++ b/data/110/873/053/3/1108730533.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.968557,
-    "geom:area_square_m":32337043155.190624,
+    "geom:area_square_m":32337043155.191147,
     "geom:bbox":"24.7977,-29.09024,27.4718,-27.10439",
     "geom:latitude":-28.23951,
     "geom:longitude":26.144391,
@@ -113,9 +113,10 @@
         "hasc:id":"ZA.FS.LE",
         "wd:id":"Q1816477"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZA",
     "wof:created":1478731973,
-    "wof:geomhash":"390386f791a36bac1fae458588846f6d",
+    "wof:geomhash":"e813af6a47cf0f65fd30c87a2783c08c",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -141,7 +142,7 @@
         "ven",
         "nbl"
     ],
-    "wof:lastmodified":1690927928,
+    "wof:lastmodified":1695886461,
     "wof:name":"Lejweleputswa",
     "wof:parent_id":85688915,
     "wof:placetype":"county",

--- a/data/110/873/053/5/1108730535.geojson
+++ b/data/110/873/053/5/1108730535.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":3.009781,
-    "geom:area_square_m":32784975354.027054,
+    "geom:area_square_m":32784975354.024963,
     "geom:bbox":"26.81813,-29.57538,29.78513,-27.00383",
     "geom:latitude":-28.241329,
     "geom:longitude":28.359735,
@@ -119,9 +119,10 @@
         "hasc:id":"ZA.FS.TM",
         "wd:id":"Q1437719"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZA",
     "wof:created":1478731975,
-    "wof:geomhash":"49e2abf1acdb3f059e986c204ad57e8f",
+    "wof:geomhash":"a1817c4db09dbdc6ba25edf04c1ffcdb",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -147,7 +148,7 @@
         "ven",
         "nbl"
     ],
-    "wof:lastmodified":1690927928,
+    "wof:lastmodified":1695886590,
     "wof:name":"Thabo Mofutsanyane",
     "wof:parent_id":85688915,
     "wof:placetype":"county",

--- a/data/110/873/053/7/1108730537.geojson
+++ b/data/110/873/053/7/1108730537.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.884909,
-    "geom:area_square_m":20703616977.431919,
+    "geom:area_square_m":20703616977.432526,
     "geom:bbox":"26.52162,-28.28424,29.015142,-26.66874",
     "geom:latitude":-27.339182,
     "geom:longitude":27.71927,
@@ -124,9 +124,10 @@
         "hasc:id":"ZA.FS.FD",
         "wd:id":"Q1410315"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZA",
     "wof:created":1478731977,
-    "wof:geomhash":"c9d1d9cd2df0d9b001f43bf9e2ed323d",
+    "wof:geomhash":"d9644ae4da31efdef1b3b5e138781c01",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -152,7 +153,7 @@
         "ven",
         "nbl"
     ],
-    "wof:lastmodified":1690927926,
+    "wof:lastmodified":1695886591,
     "wof:name":"Fezile Dabi",
     "wof:parent_id":85688915,
     "wof:placetype":"county",

--- a/data/110/873/053/9/1108730539.geojson
+++ b/data/110/873/053/9/1108730539.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.918337,
-    "geom:area_square_m":9899506425.357824,
+    "geom:area_square_m":9899506425.357815,
     "geom:bbox":"25.71936,-30.11185,27.21636,-28.650978",
     "geom:latitude":-29.331493,
     "geom:longitude":26.50053,
@@ -110,9 +110,10 @@
         "hasc:id":"ZA.FS.MT",
         "wd:id":"Q1159185"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZA",
     "wof:created":1478731979,
-    "wof:geomhash":"b74cb341ad0e233ac9a59060e2d4fde6",
+    "wof:geomhash":"6b7b33cac3d8fe803e4fe68586c687d4",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -138,7 +139,7 @@
         "ven",
         "nbl"
     ],
-    "wof:lastmodified":1690927925,
+    "wof:lastmodified":1695886460,
     "wof:name":"Mangaung",
     "wof:parent_id":85688915,
     "wof:placetype":"county",

--- a/data/110/873/054/1/1108730541.geojson
+++ b/data/110/873/054/1/1108730541.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.378005,
-    "geom:area_square_m":4180568880.27247,
+    "geom:area_square_m":4180568880.272142,
     "geom:bbox":"27.56909,-26.92383,28.86129,-26.17224",
     "geom:latitude":-26.566855,
     "geom:longitude":28.182772,
@@ -107,9 +107,10 @@
         "hasc:id":"ZA.GT.SE",
         "wd:id":"Q2038939"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZA",
     "wof:created":1478731980,
-    "wof:geomhash":"ef287d0cb1dc431e5832c46554a7b292",
+    "wof:geomhash":"7f08cb32b361d590f1b79a18cf619e66",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -135,7 +136,7 @@
         "ven",
         "nbl"
     ],
-    "wof:lastmodified":1690927924,
+    "wof:lastmodified":1695886588,
     "wof:name":"Sedibeng",
     "wof:parent_id":85688923,
     "wof:placetype":"county",

--- a/data/110/873/054/3/1108730543.geojson
+++ b/data/110/873/054/3/1108730543.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.369269,
-    "geom:area_square_m":4095315679.150505,
+    "geom:area_square_m":4095315679.150618,
     "geom:bbox":"27.15634,-26.649468,27.94085,-25.79592",
     "geom:latitude":-26.245645,
     "geom:longitude":27.555384,
@@ -118,9 +118,10 @@
         "hasc:id":"ZA.GT.WR",
         "wd:id":"Q1789890"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZA",
     "wof:created":1478731982,
-    "wof:geomhash":"2d0167ee09bc0386c4cdbedfe0348611",
+    "wof:geomhash":"20fb190dbeb33383c8b12c18a1e7c6e5",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -146,7 +147,7 @@
         "ven",
         "nbl"
     ],
-    "wof:lastmodified":1690927924,
+    "wof:lastmodified":1695886458,
     "wof:name":"West Rand",
     "wof:parent_id":85688923,
     "wof:placetype":"county",

--- a/data/110/873/054/5/1108730545.geojson
+++ b/data/110/873/054/5/1108730545.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.566199,
-    "geom:area_square_m":6310676946.159153,
+    "geom:area_square_m":6310676946.15933,
     "geom:bbox":"27.89035,-26.07809,29.09842,-25.109612",
     "geom:latitude":-25.659851,
     "geom:longitude":28.443433,
@@ -154,9 +154,10 @@
         "hasc:id":"ZA.GT.TS",
         "wd:id":"Q1094207"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZA",
     "wof:created":1478731984,
-    "wof:geomhash":"1b5a43cbd640d6b4bec45e17c77d96fd",
+    "wof:geomhash":"2b0f5efbd412ce07e1d88905542e4fb6",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -182,7 +183,7 @@
         "ven",
         "nbl"
     ],
-    "wof:lastmodified":1690927925,
+    "wof:lastmodified":1695886458,
     "wof:name":"City of Tshwane",
     "wof:parent_id":85688923,
     "wof:placetype":"county",

--- a/data/110/873/054/9/1108730549.geojson
+++ b/data/110/873/054/9/1108730549.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.450477,
-    "geom:area_square_m":4796237359.658418,
+    "geom:area_square_m":4796237359.660427,
     "geom:bbox":"29.57128,-31.08263,30.764868,-30.08437",
     "geom:latitude":-30.564942,
     "geom:longitude":30.255032,
@@ -116,9 +116,10 @@
         "hasc:id":"ZA.NL.UG",
         "wd:id":"Q2091235"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZA",
     "wof:created":1478731985,
-    "wof:geomhash":"eda88d0bb1c17d6c1ffabc3049d7085f",
+    "wof:geomhash":"b9521b08783d9983b8ee74c038c542f7",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -144,7 +145,7 @@
         "ven",
         "nbl"
     ],
-    "wof:lastmodified":1690927922,
+    "wof:lastmodified":1695886597,
     "wof:name":"Ugu",
     "wof:parent_id":85688911,
     "wof:placetype":"county",

--- a/data/110/873/055/1/1108730551.geojson
+++ b/data/110/873/055/1/1108730551.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.893531,
-    "geom:area_square_m":9614739959.175507,
+    "geom:area_square_m":9614739959.175526,
     "geom:bbox":"29.29318,-30.14472,30.91949,-28.9149",
     "geom:latitude":-29.515334,
     "geom:longitude":30.192735,
@@ -119,9 +119,10 @@
         "hasc:id":"ZA.NL.UV",
         "wd:id":"Q311803"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZA",
     "wof:created":1478731989,
-    "wof:geomhash":"5f934d5d7be585e6515eebd189177804",
+    "wof:geomhash":"14f7535ad4910398213c12fda924fb5e",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -147,7 +148,7 @@
         "ven",
         "nbl"
     ],
-    "wof:lastmodified":1690927935,
+    "wof:lastmodified":1695886584,
     "wof:name":"Umgungundlovu",
     "wof:parent_id":85688911,
     "wof:placetype":"county",

--- a/data/110/873/055/3/1108730553.geojson
+++ b/data/110/873/055/3/1108730553.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.028353,
-    "geom:area_square_m":11150405203.130333,
+    "geom:area_square_m":11150405203.129751,
     "geom:bbox":"28.87348,-29.35134,30.33784,-28.12181",
     "geom:latitude":-28.728934,
     "geom:longitude":29.654398,
@@ -107,9 +107,10 @@
         "hasc:id":"ZA.NL.UL",
         "wd:id":"Q1324549"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZA",
     "wof:created":1478731991,
-    "wof:geomhash":"539ebdaf2f6c7186c38ceb225dc7e8c1",
+    "wof:geomhash":"a2c6d5e3ef26001c514ff64d3b4cb91a",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -135,7 +136,7 @@
         "ven",
         "nbl"
     ],
-    "wof:lastmodified":1690927935,
+    "wof:lastmodified":1695886582,
     "wof:name":"Uthukela",
     "wof:parent_id":85688911,
     "wof:placetype":"county",

--- a/data/110/873/055/5/1108730555.geojson
+++ b/data/110/873/055/5/1108730555.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.798092,
-    "geom:area_square_m":8665170953.526335,
+    "geom:area_square_m":8665170953.527565,
     "geom:bbox":"29.976794,-29.29017,31.047565,-27.93056",
     "geom:latitude":-28.588952,
     "geom:longitude":30.557198,
@@ -110,9 +110,10 @@
         "hasc:id":"ZA.NL.UZ",
         "wd:id":"Q2226837"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZA",
     "wof:created":1478731993,
-    "wof:geomhash":"0a4bdbdbdd1359b35a2abc0b7166276d",
+    "wof:geomhash":"f59ffcb6fe467cb0f5d17987e0bc235d",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -138,7 +139,7 @@
         "ven",
         "nbl"
     ],
-    "wof:lastmodified":1690927936,
+    "wof:lastmodified":1695886465,
     "wof:name":"Umzinyathi",
     "wof:parent_id":85688911,
     "wof:placetype":"county",

--- a/data/110/873/055/7/1108730557.geojson
+++ b/data/110/873/055/7/1108730557.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.65009,
-    "geom:area_square_m":7114115995.375151,
+    "geom:area_square_m":7114115995.37495,
     "geom:bbox":"29.616862,-28.215172,30.69994,-27.26743",
     "geom:latitude":-27.74685,
     "geom:longitude":30.128114,
@@ -122,9 +122,10 @@
         "hasc:id":"ZA.NL.AJ",
         "wd:id":"Q452565"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZA",
     "wof:created":1478731995,
-    "wof:geomhash":"a7100978beb6c70e52383a485bd059ec",
+    "wof:geomhash":"7b62906478837190600af90255b69aa5",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -150,7 +151,7 @@
         "ven",
         "nbl"
     ],
-    "wof:lastmodified":1690927934,
+    "wof:lastmodified":1695886464,
     "wof:name":"Amajuba",
     "wof:parent_id":85688911,
     "wof:placetype":"county",

--- a/data/110/873/055/9/1108730559.geojson
+++ b/data/110/873/055/9/1108730559.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.355359,
-    "geom:area_square_m":14823162877.659925,
+    "geom:area_square_m":14823162877.659967,
     "geom:bbox":"30.44468,-28.5526,32.05014,-27.24317",
     "geom:latitude":-27.81139,
     "geom:longitude":31.294263,
@@ -128,9 +128,10 @@
         "hasc:id":"ZA.NL.ZU",
         "wd:id":"Q2309262"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZA",
     "wof:created":1478731997,
-    "wof:geomhash":"47903e54eecf2a3b9f642badc648be3b",
+    "wof:geomhash":"bc826c02ccc36b5b56cf0b0a4c566c57",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -156,7 +157,7 @@
         "ven",
         "nbl"
     ],
-    "wof:lastmodified":1690927933,
+    "wof:lastmodified":1695886461,
     "wof:name":"Zululand",
     "wof:parent_id":85688911,
     "wof:placetype":"county",

--- a/data/110/873/056/1/1108730561.geojson
+++ b/data/110/873/056/1/1108730561.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.26681,
-    "geom:area_square_m":13878496012.825493,
+    "geom:area_square_m":13878496012.828072,
     "geom:bbox":"31.69772,-28.52023,32.944985,-26.80442",
     "geom:latitude":-27.622361,
     "geom:longitude":32.329444,
@@ -110,9 +110,10 @@
         "hasc:id":"ZA.NL.UY",
         "wd:id":"Q1654018"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZA",
     "wof:created":1478731999,
-    "wof:geomhash":"3732eea235fca0b94eddf3882e95d197",
+    "wof:geomhash":"6d159e0a5414c3aae4ef4cddac39895e",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -138,7 +139,7 @@
         "ven",
         "nbl"
     ],
-    "wof:lastmodified":1690927952,
+    "wof:lastmodified":1695886616,
     "wof:name":"Umkhanyakude",
     "wof:parent_id":85688911,
     "wof:placetype":"county",

--- a/data/110/873/056/7/1108730567.geojson
+++ b/data/110/873/056/7/1108730567.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.303508,
-    "geom:area_square_m":3273663506.8832,
+    "geom:area_square_m":3273663506.883515,
     "geom:bbox":"30.70252,-29.62759,31.675314,-28.8539",
     "geom:latitude":-29.273257,
     "geom:longitude":31.142525,
@@ -119,9 +119,10 @@
         "hasc:id":"ZA.NL.IL",
         "wd:id":"Q311794"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZA",
     "wof:created":1478732004,
-    "wof:geomhash":"1c380282daf4f987b4ee21707910a95a",
+    "wof:geomhash":"856e6d77b6dfe2125bb89d8c78c03dde",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -147,7 +148,7 @@
         "ven",
         "nbl"
     ],
-    "wof:lastmodified":1690927951,
+    "wof:lastmodified":1695886577,
     "wof:name":"iLembe",
     "wof:parent_id":85688911,
     "wof:placetype":"county",

--- a/data/110/873/057/1/1108730571.geojson
+++ b/data/110/873/057/1/1108730571.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.238578,
-    "geom:area_square_m":2559072566.395596,
+    "geom:area_square_m":2559072566.393539,
     "geom:bbox":"30.56,-30.268784,31.18619,-29.50113",
     "geom:latitude":-29.834218,
     "geom:longitude":30.83614,
@@ -115,9 +115,10 @@
         "hasc:id":"ZA.NL.ET",
         "wd:id":"Q311544"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZA",
     "wof:created":1478732009,
-    "wof:geomhash":"20b707a13e324558a7cbe8066b5f038f",
+    "wof:geomhash":"29f3caab7733afe5b043e419129d553c",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -143,7 +144,7 @@
         "ven",
         "nbl"
     ],
-    "wof:lastmodified":1690927948,
+    "wof:lastmodified":1695886569,
     "wof:name":"eThekwini",
     "wof:parent_id":85688911,
     "wof:placetype":"county",

--- a/data/110/873/057/3/1108730573.geojson
+++ b/data/110/873/057/3/1108730573.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.772526,
-    "geom:area_square_m":20058569677.8848,
+    "geom:area_square_m":20058569677.884823,
     "geom:bbox":"29.85444,-24.58207,31.883835,-23.07221",
     "geom:latitude":-23.766607,
     "geom:longitude":30.836003,
@@ -116,9 +116,10 @@
         "hasc:id":"ZA.NP.MP",
         "wd:id":"Q611074"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZA",
     "wof:created":1478732013,
-    "wof:geomhash":"79685581a94d3160aa30aee58be57e56",
+    "wof:geomhash":"1b742067995f150fc28da9f4e8759cab",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -144,7 +145,7 @@
         "ven",
         "nbl"
     ],
-    "wof:lastmodified":1690927949,
+    "wof:lastmodified":1695886570,
     "wof:name":"Mopani",
     "wof:parent_id":85688935,
     "wof:placetype":"county",

--- a/data/110/873/057/5/1108730575.geojson
+++ b/data/110/873/057/5/1108730575.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.250533,
-    "geom:area_square_m":25662193621.414104,
+    "geom:area_square_m":25662193621.41415,
     "geom:bbox":"28.90197,-23.43741,31.5636,-22.12503",
     "geom:latitude":-22.754666,
     "geom:longitude":30.193599,
@@ -113,9 +113,10 @@
         "hasc:id":"ZA.NP.VH",
         "wd:id":"Q2305610"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZA",
     "wof:created":1478732016,
-    "wof:geomhash":"c16a6ee399fdfef3a87963740df7fd2e",
+    "wof:geomhash":"4d225a52141ffc91819751803a44e829",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -141,7 +142,7 @@
         "ven",
         "nbl"
     ],
-    "wof:lastmodified":1690927950,
+    "wof:lastmodified":1695886589,
     "wof:name":"Vhembe",
     "wof:parent_id":85688935,
     "wof:placetype":"county",

--- a/data/110/873/057/7/1108730577.geojson
+++ b/data/110/873/057/7/1108730577.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.918584,
-    "geom:area_square_m":21758086221.211037,
+    "geom:area_square_m":21758086221.21167,
     "geom:bbox":"28.09691,-24.640615,30.366215,-22.44744",
     "geom:latitude":-23.481628,
     "geom:longitude":29.183498,
@@ -113,9 +113,10 @@
         "hasc:id":"ZA.NP.CP",
         "wd:id":"Q692290"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZA",
     "wof:created":1478732020,
-    "wof:geomhash":"e01c5c734ae8ef0f49b12cdf1ce6d73d",
+    "wof:geomhash":"78518ccce1de6ad02aa06f578ec5880c",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -141,7 +142,7 @@
         "ven",
         "nbl"
     ],
-    "wof:lastmodified":1617129932,
+    "wof:lastmodified":1695886571,
     "wof:name":"Capricorn",
     "wof:parent_id":85688935,
     "wof:placetype":"county",

--- a/data/110/873/057/9/1108730579.geojson
+++ b/data/110/873/057/9/1108730579.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":3.991681,
-    "geom:area_square_m":45016664432.24321,
+    "geom:area_square_m":45016664432.243179,
     "geom:bbox":"26.40754,-25.32243,29.40049,-22.811053",
     "geom:latitude":-24.205144,
     "geom:longitude":27.978702,
@@ -113,9 +113,10 @@
         "hasc:id":"ZA.NP.WA",
         "wd:id":"Q2096830"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZA",
     "wof:created":1478732023,
-    "wof:geomhash":"eadb8fe794b0b3d9c6f82db38ce2f2a2",
+    "wof:geomhash":"67e01cc5ae42c91dbbb1e32d22c01107",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -141,7 +142,7 @@
         "ven",
         "nbl"
     ],
-    "wof:lastmodified":1690927947,
+    "wof:lastmodified":1695886567,
     "wof:name":"Waterberg",
     "wof:parent_id":85688935,
     "wof:placetype":"county",

--- a/data/110/873/058/1/1108730581.geojson
+++ b/data/110/873/058/1/1108730581.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.208087,
-    "geom:area_square_m":13557343844.162167,
+    "geom:area_square_m":13557343844.16234,
     "geom:bbox":"28.89162,-25.42279,30.75898,-24.20403",
     "geom:latitude":-24.828057,
     "geom:longitude":29.838029,
@@ -113,9 +113,10 @@
         "hasc:id":"ZA.MP.SK",
         "wd:id":"Q1544445"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZA",
     "wof:created":1478732027,
-    "wof:geomhash":"96505e53950d90cbe7f86618a952f866",
+    "wof:geomhash":"db98547049a5e6d5a7ca7cdc1e88e453",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -141,7 +142,7 @@
         "ven",
         "nbl"
     ],
-    "wof:lastmodified":1690927957,
+    "wof:lastmodified":1695886572,
     "wof:name":"Sekhukhune",
     "wof:parent_id":85688935,
     "wof:placetype":"county",

--- a/data/110/873/058/5/1108730585.geojson
+++ b/data/110/873/058/5/1108730585.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.887058,
-    "geom:area_square_m":31899829340.65416,
+    "geom:area_square_m":31899829340.655239,
     "geom:bbox":"28.243465,-27.50615,31.27479,-25.7118",
     "geom:latitude":-26.671001,
     "geom:longitude":29.929535,
@@ -130,9 +130,10 @@
         "hasc:id":"ZA.MP.GS",
         "wd:id":"Q1515346"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZA",
     "wof:created":1478732029,
-    "wof:geomhash":"d11ff1a43cb3f7943294caa13cf4fa14",
+    "wof:geomhash":"b1eaf9f2260a42ac359b41c7b4e4f7c7",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -158,7 +159,7 @@
         "ven",
         "nbl"
     ],
-    "wof:lastmodified":1690927958,
+    "wof:lastmodified":1695886467,
     "wof:name":"Gert Sibande",
     "wof:parent_id":85688895,
     "wof:placetype":"county",

--- a/data/110/873/058/7/1108730587.geojson
+++ b/data/110/873/058/7/1108730587.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.507294,
-    "geom:area_square_m":16792266476.350323,
+    "geom:area_square_m":16792266476.349316,
     "geom:bbox":"28.37926,-26.38429,30.66562,-24.90153",
     "geom:latitude":-25.712222,
     "geom:longitude":29.424309,
@@ -113,9 +113,10 @@
         "hasc:id":"ZA.MP.NK",
         "wd:id":"Q1856181"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZA",
     "wof:created":1478732031,
-    "wof:geomhash":"938d480fe0d35443b4f4699b43cd9218",
+    "wof:geomhash":"f530d8878605da24761266aa3f147ca3",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -141,7 +142,7 @@
         "ven",
         "nbl"
     ],
-    "wof:lastmodified":1690927957,
+    "wof:lastmodified":1695886467,
     "wof:name":"Nkangala",
     "wof:parent_id":85688895,
     "wof:placetype":"county",

--- a/data/110/873/058/9/1108730589.geojson
+++ b/data/110/873/058/9/1108730589.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.495621,
-    "geom:area_square_m":27955557750.758427,
+    "geom:area_square_m":27955557750.758553,
     "geom:bbox":"29.97895,-25.9996,32.03359,-23.98124",
     "geom:latitude":-25.048738,
     "geom:longitude":31.254664,
@@ -119,9 +119,10 @@
         "hasc:id":"ZA.MP.EH",
         "wd:id":"Q1244497"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZA",
     "wof:created":1478732032,
-    "wof:geomhash":"5073b5b2f5b63127ed6a51920ad6f9a0",
+    "wof:geomhash":"266a3f4aa5648202054d422c1c5d1860",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -147,7 +148,7 @@
         "ven",
         "nbl"
     ],
-    "wof:lastmodified":1690927956,
+    "wof:lastmodified":1695886467,
     "wof:name":"Ehlanzeni",
     "wof:parent_id":85688895,
     "wof:placetype":"county",

--- a/data/110/873/059/1/1108730591.geojson
+++ b/data/110/873/059/1/1108730591.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.485443,
-    "geom:area_square_m":27371093129.53764,
+    "geom:area_square_m":27371093129.53611,
     "geom:bbox":"21.7692,-27.98787,24.11862,-25.98256",
     "geom:latitude":-27.04638,
     "geom:longitude":23.046385,
@@ -116,9 +116,10 @@
         "hasc:id":"ZA.NC.KG",
         "wd:id":"Q384731"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZA",
     "wof:created":1478732034,
-    "wof:geomhash":"2ba4889336c1822e1982601083c573ac",
+    "wof:geomhash":"df3ec67b2a4ebf01a0ae87dfd0b72d5b",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -144,7 +145,7 @@
         "ven",
         "nbl"
     ],
-    "wof:lastmodified":1690927942,
+    "wof:lastmodified":1695886466,
     "wof:name":"John Taolo Gaetsewe",
     "wof:parent_id":85688899,
     "wof:placetype":"county",

--- a/data/110/873/059/3/1108730593.geojson
+++ b/data/110/873/059/3/1108730593.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":11.92438,
-    "geom:area_square_m":126974689497.787872,
+    "geom:area_square_m":126974689497.792404,
     "geom:bbox":"16.45189,-32.944995,22.20628,-28.03276",
     "geom:latitude":-30.535609,
     "geom:longitude":19.428918,
@@ -110,9 +110,10 @@
         "hasc:id":"ZA.NC.NA",
         "wd:id":"Q617646"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZA",
     "wof:created":1478732035,
-    "wof:geomhash":"0cac6c81fb95b4668b1ee8e896aa55a6",
+    "wof:geomhash":"62417d6aaaf4ee8f995dfe2b503f277f",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -138,7 +139,7 @@
         "ven",
         "nbl"
     ],
-    "wof:lastmodified":1690927943,
+    "wof:lastmodified":1695886559,
     "wof:name":"Namakwa",
     "wof:parent_id":85688899,
     "wof:placetype":"county",

--- a/data/110/873/059/5/1108730595.geojson
+++ b/data/110/873/059/5/1108730595.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":9.697337,
-    "geom:area_square_m":103529420920.417892,
+    "geom:area_square_m":103529420920.416443,
     "geom:bbox":"21.07291,-31.9777,25.54933,-28.44446",
     "geom:latitude":-30.28918,
     "geom:longitude":23.258157,
@@ -110,9 +110,10 @@
         "hasc:id":"ZA.NC.PS",
         "wd:id":"Q1886098"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZA",
     "wof:created":1478732039,
-    "wof:geomhash":"1ffe6cb7d4fdcb680abcf62cd0b017a1",
+    "wof:geomhash":"6d9ee51a1fdad86e9a8c3504ea9e6e30",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -138,7 +139,7 @@
         "ven",
         "nbl"
     ],
-    "wof:lastmodified":1690927945,
+    "wof:lastmodified":1695886586,
     "wof:name":"Pixley ka Seme",
     "wof:parent_id":85688899,
     "wof:placetype":"county",

--- a/data/110/873/059/7/1108730597.geojson
+++ b/data/110/873/059/7/1108730597.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":9.403598,
-    "geom:area_square_m":102647150046.24646,
+    "geom:area_square_m":102647150046.248657,
     "geom:bbox":"19.50929,-30.04441,23.89142,-24.76586",
     "geom:latitude":-28.000241,
     "geom:longitude":21.184042,
@@ -116,9 +116,10 @@
         "hasc:id":"ZA.NC.SY",
         "wd:id":"Q1773268"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZA",
     "wof:created":1478732041,
-    "wof:geomhash":"395e5281b5166f8677df6fa5cc768630",
+    "wof:geomhash":"42fef986165949baebbf8861e60e6d50",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -144,7 +145,7 @@
         "ven",
         "nbl"
     ],
-    "wof:lastmodified":1690927941,
+    "wof:lastmodified":1695886565,
     "wof:name":"Z F Mgcawu",
     "wof:parent_id":85688899,
     "wof:placetype":"county",

--- a/data/110/873/059/9/1108730599.geojson
+++ b/data/110/873/059/9/1108730599.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.180796,
-    "geom:area_square_m":12855416960.504742,
+    "geom:area_square_m":12855416960.504576,
     "geom:bbox":"23.58093,-29.05099,25.04791,-27.60464",
     "geom:latitude":-28.300035,
     "geom:longitude":24.38188,
@@ -115,9 +115,10 @@
         "hasc:id":"ZA.NC.FB",
         "wd:id":"Q1263830"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZA",
     "wof:created":1478732044,
-    "wof:geomhash":"00b95c44d9587129bbd8ece8f9646f9a",
+    "wof:geomhash":"4e94556860072b5da4ce34416423e731",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -143,7 +144,7 @@
         "ven",
         "nbl"
     ],
-    "wof:lastmodified":1690927941,
+    "wof:lastmodified":1695886587,
     "wof:name":"Frances Baard",
     "wof:parent_id":85688899,
     "wof:placetype":"county",

--- a/data/110/873/060/3/1108730603.geojson
+++ b/data/110/873/060/3/1108730603.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.645116,
-    "geom:area_square_m":18371555965.366951,
+    "geom:area_square_m":18371555965.366528,
     "geom:bbox":"26.38498,-26.14289,28.29835,-24.71863",
     "geom:latitude":-25.42612,
     "geom:longitude":27.2243,
@@ -102,9 +102,10 @@
         "hasc:id":"ZA.NW.BP",
         "wd:id":"Q891165"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZA",
     "wof:created":1478732045,
-    "wof:geomhash":"e94266c914e52f97102d7150cf610b47",
+    "wof:geomhash":"dd6102f073acf778bb3d48bdd8bae382",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -130,7 +131,7 @@
         "ven",
         "nbl"
     ],
-    "wof:lastmodified":1690927960,
+    "wof:lastmodified":1695886470,
     "wof:name":"Bojanala",
     "wof:parent_id":85688931,
     "wof:placetype":"county",

--- a/data/110/873/060/5/1108730605.geojson
+++ b/data/110/873/060/5/1108730605.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.533737,
-    "geom:area_square_m":28169402386.957047,
+    "geom:area_square_m":28169402386.956657,
     "geom:bbox":"24.46507,-26.96774,26.80708,-24.63663",
     "geom:latitude":-25.952911,
     "geom:longitude":25.809933,
@@ -118,9 +118,10 @@
         "hasc:id":"ZA.NW.MM",
         "wd:id":"Q1984191"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZA",
     "wof:created":1478732047,
-    "wof:geomhash":"58b234e3dc9f0f6c0e87d9903ac63fd4",
+    "wof:geomhash":"d9626deba6e93648a0c630d048ee4af5",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -146,7 +147,7 @@
         "ven",
         "nbl"
     ],
-    "wof:lastmodified":1690927961,
+    "wof:lastmodified":1695886600,
     "wof:name":"Ngaka Modiri Molema",
     "wof:parent_id":85688931,
     "wof:placetype":"county",

--- a/data/110/873/060/7/1108730607.geojson
+++ b/data/110/873/060/7/1108730607.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":3.967175,
-    "geom:area_square_m":43845046570.492981,
+    "geom:area_square_m":43845046570.494011,
     "geom:bbox":"22.62903,-28.113209,25.83482,-25.27325",
     "geom:latitude":-26.637572,
     "geom:longitude":24.275574,
@@ -112,9 +112,10 @@
         "hasc:id":"ZA.NW.RM",
         "wd:id":"Q1254171"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZA",
     "wof:created":1478732049,
-    "wof:geomhash":"f2b5f58a0ce198719fc7196f25ac1294",
+    "wof:geomhash":"caf4c5af961359d3359fae316d20f452",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -140,7 +141,7 @@
         "ven",
         "nbl"
     ],
-    "wof:lastmodified":1690927960,
+    "wof:lastmodified":1695886601,
     "wof:name":"Dr Ruth Segomotsi Mompati",
     "wof:parent_id":85688931,
     "wof:placetype":"county",

--- a/data/110/873/060/9/1108730609.geojson
+++ b/data/110/873/060/9/1108730609.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.331796,
-    "geom:area_square_m":14697736083.481401,
+    "geom:area_square_m":14697736083.480562,
     "geom:bbox":"25.61015,-27.73677,27.60284,-26.03163",
     "geom:latitude":-26.807476,
     "geom:longitude":26.56756,
@@ -121,9 +121,10 @@
         "hasc:id":"ZA.NW.KK",
         "wd:id":"Q1150452"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZA",
     "wof:created":1478732051,
-    "wof:geomhash":"8c5d92d806aca686f755b09c925421b6",
+    "wof:geomhash":"6324fc9b2228413f735f27e33471c2c9",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -149,7 +150,7 @@
         "ven",
         "nbl"
     ],
-    "wof:lastmodified":1690927959,
+    "wof:lastmodified":1695886469,
     "wof:name":"Dr Kenneth Kaunda",
     "wof:parent_id":85688931,
     "wof:placetype":"county",

--- a/data/110/873/061/1/1108730611.geojson
+++ b/data/110/873/061/1/1108730611.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.238366,
-    "geom:area_square_m":2446604143.974697,
+    "geom:area_square_m":2446604143.974738,
     "geom:bbox":"18.30722,-34.35834,19.005338,-33.471276",
     "geom:latitude":-33.892707,
     "geom:longitude":18.594297,
@@ -142,9 +142,10 @@
         "hasc:id":"ZA.WC.CT",
         "wd:id":"Q1185115"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZA",
     "wof:created":1478732052,
-    "wof:geomhash":"c91da93d7d6f828dae0bd54c5dbd0e82",
+    "wof:geomhash":"9f8afcb3837fdf37e30e8000134378c8",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -170,7 +171,7 @@
         "ven",
         "nbl"
     ],
-    "wof:lastmodified":1690927937,
+    "wof:lastmodified":1695886608,
     "wof:name":"City of Cape Town",
     "wof:parent_id":85688905,
     "wof:placetype":"county",

--- a/data/110/873/061/3/1108730613.geojson
+++ b/data/110/873/061/3/1108730613.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.973226,
-    "geom:area_square_m":31142530578.674179,
+    "geom:area_square_m":31142530578.675472,
     "geom:bbox":"17.75735,-33.68703,19.51636,-30.43026",
     "geom:latitude":-32.095056,
     "geom:longitude":18.626953,
@@ -121,9 +121,10 @@
         "hasc:id":"ZA.WC.WC",
         "wd:id":"Q2562901"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZA",
     "wof:created":1478732054,
-    "wof:geomhash":"fbb25e995e1dce74f4fa9afae0d75efd",
+    "wof:geomhash":"87839ac653c12a113ac724918173077a",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -149,7 +150,7 @@
         "ven",
         "nbl"
     ],
-    "wof:lastmodified":1690927938,
+    "wof:lastmodified":1695886793,
     "wof:name":"West Coast",
     "wof:parent_id":85688905,
     "wof:placetype":"county",

--- a/data/110/873/061/5/1108730615.geojson
+++ b/data/110/873/061/5/1108730615.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.07939,
-    "geom:area_square_m":21484116191.1479,
+    "geom:area_square_m":21484116191.148148,
     "geom:bbox":"18.70833,-34.11726,20.57713,-32.18449",
     "geom:latitude":-33.322508,
     "geom:longitude":19.689985,
@@ -121,9 +121,10 @@
         "hasc:id":"ZA.WC.CW",
         "wd:id":"Q1974486"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZA",
     "wof:created":1478732058,
-    "wof:geomhash":"cedc79b7c45b6df1ad5e52811394548a",
+    "wof:geomhash":"cc6a1b3b271c228ba6cf1b0548a57f01",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -149,7 +150,7 @@
         "ven",
         "nbl"
     ],
-    "wof:lastmodified":1690927940,
+    "wof:lastmodified":1695886466,
     "wof:name":"Cape Winelands",
     "wof:parent_id":85688905,
     "wof:placetype":"county",

--- a/data/110/873/061/7/1108730617.geojson
+++ b/data/110/873/061/7/1108730617.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.198024,
-    "geom:area_square_m":12243167245.93734,
+    "geom:area_square_m":12243167245.938816,
     "geom:bbox":"18.80954,-34.83417,21.01034,-33.62197",
     "geom:latitude":-34.261336,
     "geom:longitude":19.939916,
@@ -113,9 +113,10 @@
         "hasc:id":"ZA.WC.OV",
         "wd:id":"Q1899307"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZA",
     "wof:created":1478732059,
-    "wof:geomhash":"c6fef4d2b02e04f1c57a214de0820d42",
+    "wof:geomhash":"f2b8a18275f8385598b7a7404e010440",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -141,7 +142,7 @@
         "ven",
         "nbl"
     ],
-    "wof:lastmodified":1617131070,
+    "wof:lastmodified":1695886609,
     "wof:name":"Overberg",
     "wof:parent_id":85688905,
     "wof:placetype":"county",

--- a/data/110/873/062/3/1108730623.geojson
+++ b/data/110/873/062/3/1108730623.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":3.733575,
-    "geom:area_square_m":38879377578.129631,
+    "geom:area_square_m":38879377578.129883,
     "geom:bbox":"20.20218,-33.52778,24.22241,-31.58346",
     "geom:latitude":-32.628124,
     "geom:longitude":22.211924,
@@ -121,9 +121,10 @@
         "hasc:id":"ZA.WC.CK",
         "wd:id":"Q1053888"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZA",
     "wof:created":1478732065,
-    "wof:geomhash":"7fff66dd1c8d48620d3ebd302244c1ce",
+    "wof:geomhash":"55842a5b72d582cd9535f0f6a4fd170f",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -149,7 +150,7 @@
         "ven",
         "nbl"
     ],
-    "wof:lastmodified":1690927921,
+    "wof:lastmodified":1695886589,
     "wof:name":"Central Karoo",
     "wof:parent_id":85688905,
     "wof:placetype":"county",

--- a/data/176/296/620/1/1762966201.geojson
+++ b/data/176/296/620/1/1762966201.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":5.624117,
-    "geom:area_square_m":58277869589.584816,
+    "geom:area_square_m":58277869559.026291,
     "geom:bbox":"22.73574,-34.21386,27.1356,-31.68851",
     "geom:latitude":-33.065855,
     "geom:longitude":24.775846,
@@ -145,7 +145,7 @@
     },
     "wof:country":"ZA",
     "wof:created":1478731953,
-    "wof:geomhash":"12ea0c3e5ea5f28e25a7b3e65811863e",
+    "wof:geomhash":"c940514fdfeb33d5a862fbd4dee085f4",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -171,7 +171,7 @@
         "ven",
         "nbl"
     ],
-    "wof:lastmodified":1690928376,
+    "wof:lastmodified":1695886541,
     "wof:name":"Sarah Baartman",
     "wof:parent_id":85688927,
     "wof:placetype":"county",

--- a/data/176/296/620/3/1762966203.geojson
+++ b/data/176/296/620/3/1762966203.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.758381,
-    "geom:area_square_m":8225388821.957288,
+    "geom:area_square_m":8225388821.956285,
     "geom:bbox":"30.62047,-29.17479,32.414841,-28.35042",
     "geom:latitude":-28.700462,
     "geom:longitude":31.515272,
@@ -85,7 +85,7 @@
     },
     "wof:country":"ZA",
     "wof:created":1478732001,
-    "wof:geomhash":"9c2f4c4e0e1505f16361fa2b64f498bb",
+    "wof:geomhash":"25f97e1982e195532544a8bf718f9778",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -111,7 +111,7 @@
         "ven",
         "nbl"
     ],
-    "wof:lastmodified":1646701133,
+    "wof:lastmodified":1695886544,
     "wof:name":"King Cetshwayo",
     "wof:parent_id":85688911,
     "wof:placetype":"county",

--- a/data/176/296/620/5/1762966205.geojson
+++ b/data/176/296/620/5/1762966205.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.972202,
-    "geom:area_square_m":10398333943.700584,
+    "geom:area_square_m":10398333943.701694,
     "geom:bbox":"29.01474,-30.67173,30.44549,-29.496576",
     "geom:latitude":-30.118452,
     "geom:longitude":29.654125,
@@ -85,7 +85,7 @@
     },
     "wof:country":"ZA",
     "wof:created":1478732007,
-    "wof:geomhash":"27cd736d07a2f5aef6cd69539ff2ac00",
+    "wof:geomhash":"c3e4d72dfe232822261b8e91280eecbd",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -111,7 +111,7 @@
         "ven",
         "nbl"
     ],
-    "wof:lastmodified":1646701232,
+    "wof:lastmodified":1695886546,
     "wof:name":"Harry Gwala",
     "wof:parent_id":85688911,
     "wof:placetype":"county",

--- a/data/176/296/620/7/1762966207.geojson
+++ b/data/176/296/620/7/1762966207.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.272098,
-    "geom:area_square_m":23340380232.080219,
+    "geom:area_square_m":23340380232.095692,
     "geom:bbox":"20.50315,-34.43906,23.7033,-33.31496",
     "geom:latitude":-33.821391,
     "geom:longitude":22.012627,
@@ -136,7 +136,7 @@
     },
     "wof:country":"ZA",
     "wof:created":1478732062,
-    "wof:geomhash":"2969373871a277fb69a16a4c3f81711a",
+    "wof:geomhash":"2e022be61b30593c37c17d32f015de13",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -162,7 +162,7 @@
         "ven",
         "nbl"
     ],
-    "wof:lastmodified":1690928374,
+    "wof:lastmodified":1695886549,
     "wof:name":"Garden Route",
     "wof:parent_id":85688905,
     "wof:placetype":"county",

--- a/data/856/338/13/85633813.geojson
+++ b/data/856/338/13/85633813.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":113.103209,
-    "geom:area_square_m":1221549844512.443848,
+    "geom:area_square_m":1221549844512.449463,
     "geom:bbox":"16.47055,-46.965814,37.978281,-22.126452",
     "geom:latitude":-29.001052,
     "geom:longitude":25.087733,
@@ -13,6 +13,9 @@
     "iso:country":"ZA",
     "itu:country_code":[
         "27"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "country"
     ],
     "label:eng_x_preferred_shortcode":[
         "ZA"
@@ -1390,7 +1393,8 @@
         "naturalearth"
     ],
     "src:lbl_centroid":"mapshaper",
-    "src:population":"wk",
+    "src:population":"naturalearth",
+    "src:population_year":"2019",
     "statoids:dial":"27",
     "statoids:ds":"ZA",
     "statoids:fifa":"RSA",
@@ -1453,7 +1457,7 @@
         "meso",
         "naturalearth"
     ],
-    "wof:geomhash":"25e0d1cf45d167b88e1ac9f2bdf7f834",
+    "wof:geomhash":"725c36e80bee086990e05216aa5526c3",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -1477,12 +1481,12 @@
         "ven",
         "nbl"
     ],
-    "wof:lastmodified":1690927901,
+    "wof:lastmodified":1694492087,
     "wof:name":"South Africa",
     "wof:parent_id":102191573,
     "wof:placetype":"country",
-    "wof:population":54002000,
-    "wof:population_rank":16,
+    "wof:population":58558270,
+    "wof:population_rank":18,
     "wof:repo":"whosonfirst-data-admin-za",
     "wof:shortcode":"ZA",
     "wof:superseded_by":[],

--- a/data/856/338/13/85633813.geojson
+++ b/data/856/338/13/85633813.geojson
@@ -1435,6 +1435,7 @@
         "hasc:id":"ZA",
         "icao:code":"ZS",
         "ioc:id":"RSA",
+        "iso:code":"ZA",
         "itu:id":"AFS",
         "loc:id":"n79023005",
         "m49:code":"710",
@@ -1449,6 +1450,7 @@
         "wk:page":"South Africa",
         "wmo:id":"ZA"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"ZA",
     "wof:country_alpha3":"ZAF",
     "wof:geom_alt":[
@@ -1481,7 +1483,7 @@
         "ven",
         "nbl"
     ],
-    "wof:lastmodified":1694639540,
+    "wof:lastmodified":1695881198,
     "wof:name":"South Africa",
     "wof:parent_id":102191573,
     "wof:placetype":"country",

--- a/data/856/338/13/85633813.geojson
+++ b/data/856/338/13/85633813.geojson
@@ -1394,7 +1394,7 @@
     ],
     "src:lbl_centroid":"mapshaper",
     "src:population":"naturalearth",
-    "src:population_year":"2019",
+    "src:population_date":"2019",
     "statoids:dial":"27",
     "statoids:ds":"ZA",
     "statoids:fifa":"RSA",
@@ -1481,7 +1481,7 @@
         "ven",
         "nbl"
     ],
-    "wof:lastmodified":1694492087,
+    "wof:lastmodified":1694639540,
     "wof:name":"South Africa",
     "wof:parent_id":102191573,
     "wof:placetype":"country",

--- a/data/856/888/95/85688895.geojson
+++ b/data/856/888/95/85688895.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":6.889973,
-    "geom:area_square_m":76647653567.76387,
+    "geom:area_square_m":76647653567.762329,
     "geom:bbox":"28.243465,-27.50615,32.03359,-23.98124",
     "geom:latitude":-25.873651,
     "geom:longitude":30.298984,
@@ -432,15 +432,17 @@
         "gn:id":1085595,
         "gp:id":2346983,
         "hasc:id":"ZA.NL",
+        "iso:code":"ZA-NL",
         "iso:id":"ZA-NL",
         "unlc:id":"ZA-MP",
         "wd:id":"Q132410"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"ZA",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"8fc0bb777dad45b9c96cd5a229fe6a68",
+    "wof:geomhash":"83d73ae566d3fade582adec099945b17",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -465,7 +467,7 @@
         "ven",
         "nbl"
     ],
-    "wof:lastmodified":1690927915,
+    "wof:lastmodified":1695884901,
     "wof:name":"Mpumalanga",
     "wof:parent_id":85633813,
     "wof:placetype":"region",

--- a/data/856/888/99/85688899.geojson
+++ b/data/856/888/99/85688899.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":34.691554,
-    "geom:area_square_m":373377770583.423889,
+    "geom:area_square_m":373377770583.407776,
     "geom:bbox":"16.45189,-32.944995,25.54933,-24.76586",
     "geom:latitude":-29.453405,
     "geom:longitude":21.402809,
@@ -454,15 +454,17 @@
         "gn:id":1085596,
         "gp:id":2346985,
         "hasc:id":"ZA.NC",
+        "iso:code":"ZA-NC",
         "iso:id":"ZA-NC",
         "unlc:id":"ZA-NC",
         "wd:id":"Q132418"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"ZA",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"90e58b5c2e696a4b3019fb30789d298f",
+    "wof:geomhash":"81fcb11d531dcb3324ba6b8fe70f0c80",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -487,7 +489,7 @@
         "ven",
         "nbl"
     ],
-    "wof:lastmodified":1690927916,
+    "wof:lastmodified":1695884641,
     "wof:name":"Northern Cape",
     "wof:parent_id":85633813,
     "wof:placetype":"region",

--- a/data/856/889/05/85688905.geojson
+++ b/data/856/889/05/85688905.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":12.494678,
-    "geom:area_square_m":129536175974.101624,
+    "geom:area_square_m":129536175974.105469,
     "geom:bbox":"17.75735,-34.83417,24.22241,-30.43026",
     "geom:latitude":-33.014548,
     "geom:longitude":20.616038,
@@ -456,15 +456,17 @@
         "gn:id":1085599,
         "gp:id":2346987,
         "hasc:id":"ZA.WC",
+        "iso:code":"ZA-WC",
         "iso:id":"ZA-WC",
         "unlc:id":"ZA-WC",
         "wd:id":"Q127167"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"ZA",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"02e79e38f96578059cd795f5410b524c",
+    "wof:geomhash":"7dc7db9faeb31478de3eae994a4f809a",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -489,7 +491,7 @@
         "ven",
         "nbl"
     ],
-    "wof:lastmodified":1690927904,
+    "wof:lastmodified":1695884600,
     "wof:name":"Western Cape",
     "wof:parent_id":85633813,
     "wof:placetype":"region",

--- a/data/856/889/11/85688911.geojson
+++ b/data/856/889/11/85688911.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":8.71538,
-    "geom:area_square_m":94498786981.974533,
+    "geom:area_square_m":94498786981.976013,
     "geom:bbox":"28.87348,-31.08263,32.944985,-26.80442",
     "geom:latitude":-28.716585,
     "geom:longitude":30.748559,
@@ -460,15 +460,17 @@
         "gn:id":972062,
         "gp:id":2346982,
         "hasc:id":"ZA.FS",
+        "iso:code":"ZA-FS",
         "iso:id":"ZA-FS",
         "unlc:id":"ZA-NL",
         "wd:id":"Q81725"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"ZA",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"dbf30eb8a280548f04692921cce0d643",
+    "wof:geomhash":"2c3026fd0dafa90b9535ee13314e5492",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -493,7 +495,7 @@
         "ven",
         "nbl"
     ],
-    "wof:lastmodified":1690927910,
+    "wof:lastmodified":1695884613,
     "wof:name":"Kwazulu-Natal",
     "wof:parent_id":85633813,
     "wof:placetype":"region",

--- a/data/856/889/15/85688915.geojson
+++ b/data/856/889/15/85688915.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":11.979428,
-    "geom:area_square_m":130016895589.495377,
+    "geom:area_square_m":130016895589.486801,
     "geom:bbox":"24.34662,-30.69408,29.78513,-26.66874",
     "geom:latitude":-28.614403,
     "geom:longitude":26.867264,
@@ -147,14 +147,16 @@
         "gn:id":967573,
         "gp:id":2346980,
         "hasc:id":"ZA.MP",
+        "iso:code":"ZA-MP",
         "iso:id":"ZA-MP",
         "unlc:id":"ZA-FS"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"ZA",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"a352d06cec83404e0d8e4ba64068eee2",
+    "wof:geomhash":"a1e335431c9698eebaf2ae7982f24860",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -179,7 +181,7 @@
         "ven",
         "nbl"
     ],
-    "wof:lastmodified":1627523014,
+    "wof:lastmodified":1695884756,
     "wof:name":"Free State",
     "wof:parent_id":85633813,
     "wof:placetype":"region",

--- a/data/856/889/23/85688923.geojson
+++ b/data/856/889/23/85688923.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.640382,
-    "geom:area_square_m":18213880184.357513,
+    "geom:area_square_m":18213880184.357483,
     "geom:bbox":"27.15634,-26.92383,29.09842,-25.109612",
     "geom:latitude":-26.106147,
     "geom:longitude":28.125779,
@@ -460,15 +460,17 @@
         "gn:id":1085594,
         "gp:id":2346981,
         "hasc:id":"ZA.GT",
+        "iso:code":"ZA-GT",
         "iso:id":"ZA-GT",
         "unlc:id":"ZA-GT",
         "wd:id":"Q133083"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"ZA",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"e873e72cff97cab31cbf4fc0b5a8adb3",
+    "wof:geomhash":"63e3f717c71cada6d2b4357a0a468963",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -493,7 +495,7 @@
         "ven",
         "nbl"
     ],
-    "wof:lastmodified":1690927914,
+    "wof:lastmodified":1695884902,
     "wof:name":"Gauteng",
     "wof:parent_id":85633813,
     "wof:placetype":"region",

--- a/data/856/889/27/85688927.geojson
+++ b/data/856/889/27/85688927.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":16.154668,
-    "geom:area_square_m":169093435637.630737,
+    "geom:area_square_m":169093435637.635193,
     "geom:bbox":"22.73574,-34.21386,30.19472,-30.0018",
     "geom:latitude":-32.154027,
     "geom:longitude":26.446361,
@@ -447,15 +447,17 @@
         "gn:id":1085593,
         "gp:id":2346979,
         "hasc:id":"ZA.EC",
+        "iso:code":"ZA-EC",
         "iso:id":"ZA-EC",
         "unlc:id":"ZA-EC",
         "wd:id":"Q130840"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"ZA",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"01fb05090a7dedb221db7cac2b65b302",
+    "wof:geomhash":"5b73d4373535119a13a198c086d71d9f",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -480,7 +482,7 @@
         "ven",
         "nbl"
     ],
-    "wof:lastmodified":1690927908,
+    "wof:lastmodified":1695884579,
     "wof:name":"Eastern Cape",
     "wof:parent_id":85633813,
     "wof:placetype":"region",

--- a/data/856/889/31/85688931.geojson
+++ b/data/856/889/31/85688931.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":9.477824,
-    "geom:area_square_m":105083741032.655075,
+    "geom:area_square_m":105083741032.654114,
     "geom:bbox":"22.62903,-28.113209,28.29835,-24.63663",
     "geom:latitude":-26.268135,
     "geom:longitude":25.519648,
@@ -422,15 +422,17 @@
         "gn:id":1085598,
         "gp:id":2346984,
         "hasc:id":"ZA.NW",
+        "iso:code":"ZA-NW",
         "iso:id":"ZA-NW",
         "unlc:id":"ZA-NW",
         "wd:id":"Q165956"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"ZA",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"ec487c872112e396ce4d784d20b72926",
+    "wof:geomhash":"d726e198d459946cfe4800dc342b4cdc",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -455,7 +457,7 @@
         "ven",
         "nbl"
     ],
-    "wof:lastmodified":1690927913,
+    "wof:lastmodified":1695884900,
     "wof:name":"North West",
     "wof:parent_id":85633813,
     "wof:placetype":"region",

--- a/data/856/889/35/85688935.geojson
+++ b/data/856/889/35/85688935.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":11.141412,
-    "geom:area_square_m":126052857771.614029,
+    "geom:area_square_m":126052857771.61554,
     "geom:bbox":"26.40754,-25.42279,31.883835,-22.12503",
     "geom:latitude":-23.785335,
     "geom:longitude":29.289763,
@@ -467,14 +467,16 @@
         "gn:id":1085597,
         "gp:id":2346986,
         "hasc:id":"ZA.NP",
+        "iso:code":"ZA-LP",
         "iso:id":"ZA-LP",
         "wd:id":"Q134907"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"ZA",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"5cf6130cc1ae14b8912c14795c0a8c5d",
+    "wof:geomhash":"0bdd778080e644e9643d86a616e3129f",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -499,7 +501,7 @@
         "ven",
         "nbl"
     ],
-    "wof:lastmodified":1690927902,
+    "wof:lastmodified":1695884899,
     "wof:name":"Limpopo",
     "wof:parent_id":85633813,
     "wof:placetype":"region",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.